### PR TITLE
Improve accuracy of the Internal Spin Bit

### DIFF
--- a/quiche/quic/core/quic_connection.cc
+++ b/quiche/quic/core/quic_connection.cc
@@ -1150,7 +1150,6 @@ void QuicConnection::OnSuccessfulMigration(bool is_port_change) {
   // TODO(b/159074035): notify SentPacketManger with RTT sample from probing.
   if (version().HasIetfQuicFrames() && !is_port_change) {
     sent_packet_manager_.OnConnectionMigration(/*reset_send_algorithm=*/true);
-    packet_creator_.ResetSpinBit();
   }
 }
 

--- a/quiche/quic/core/quic_connection.cc
+++ b/quiche/quic/core/quic_connection.cc
@@ -2495,8 +2495,9 @@ QuicConsumedData QuicConnection::SendStreamData(QuicStreamId id,
   // a SHLO from the server, leading to two different decrypters at the
   // server.)
   ScopedPacketFlusher flusher(this);
-  QuicTime::Delta latest_rtt = sent_packet_manager_.GetRttStats()->latest_rtt();
-  return packet_creator_.ConsumeData(id, write_length, offset, state, latest_rtt);
+  return packet_creator_.ConsumeData(
+      id, write_length, offset, state,
+      sent_packet_manager_.GetRttStats()->latest_rtt());
 }
 
 bool QuicConnection::SendControlFrame(const QuicFrame& frame) {
@@ -4053,6 +4054,9 @@ void QuicConnection::MaybeCreateMultiPortPath() {
 }
 
 void QuicConnection::SendOrQueuePacket(SerializedPacket packet) {
+  packet_creator_.MaybeUpdateLatestRtt(
+    sent_packet_manager_.GetRttStats()->latest_rtt()
+    )
   // The caller of this function is responsible for checking CanWrite().
   WritePacket(&packet);
 }

--- a/quiche/quic/core/quic_connection.cc
+++ b/quiche/quic/core/quic_connection.cc
@@ -308,7 +308,7 @@ QuicConnection::QuicConnection(
           arena_.New<MultiPortProbingAlarmDelegate>(this), &arena_)),
       visitor_(nullptr),
       debug_visitor_(nullptr),
-      packet_creator_(server_connection_id, &framer_, random_generator_, this),
+      packet_creator_(server_connection_id, &framer_, random_generator_, this, clock_),
       last_received_packet_info_(clock_->ApproximateNow()),
       sent_packet_manager_(perspective, clock_, random_generator_, &stats_,
                            GetDefaultCongestionControlType()),

--- a/quiche/quic/core/quic_connection.cc
+++ b/quiche/quic/core/quic_connection.cc
@@ -4053,7 +4053,6 @@ void QuicConnection::MaybeCreateMultiPortPath() {
 }
 
 void QuicConnection::SendOrQueuePacket(SerializedPacket packet) {
-  FlipSpinBit(&packet);
   // The caller of this function is responsible for checking CanWrite().
   WritePacket(&packet);
 }

--- a/quiche/quic/core/quic_connection.cc
+++ b/quiche/quic/core/quic_connection.cc
@@ -1150,6 +1150,7 @@ void QuicConnection::OnSuccessfulMigration(bool is_port_change) {
   // TODO(b/159074035): notify SentPacketManger with RTT sample from probing.
   if (version().HasIetfQuicFrames() && !is_port_change) {
     sent_packet_manager_.OnConnectionMigration(/*reset_send_algorithm=*/true);
+    packet_creator_.ResetSpinBit();
   }
 }
 
@@ -6707,8 +6708,6 @@ void QuicConnection::CancelPathValidation() {
   path_validator_.CancelPathValidation();
 }
 
-// On path migration update Connection ID: if it returns true
-// we should reset Spin Bit and marking interval.
 bool QuicConnection::UpdateConnectionIdsOnMigration(
     const QuicSocketAddress& self_address,
     const QuicSocketAddress& peer_address) {
@@ -6799,8 +6798,6 @@ bool QuicConnection::MigratePath(const QuicSocketAddress& self_address,
       }
       return false;
     }
-    // If we are here Connection ID has been updated as result
-    // of a path migration.
     if (packet_creator_.GetServerConnectionId().length() !=
         default_path_.server_connection_id.length()) {
       packet_creator_.FlushCurrentPacket();

--- a/quiche/quic/core/quic_connection.h
+++ b/quiche/quic/core/quic_connection.h
@@ -1945,9 +1945,6 @@ class QUIC_EXPORT_PRIVATE QuicConnection
   // Returns true if |address| is known server address.
   bool IsKnownServerAddress(const QuicSocketAddress& address) const;
 
-  // Flips the Spin Bit according to the Internal Spin Bit logic.
-  void FlipSpinBit(SerializedPacket* packet);
-
   QuicConnectionContext context_;
 
   QuicFramer framer_;

--- a/quiche/quic/core/quic_dispatcher.cc
+++ b/quiche/quic/core/quic_dispatcher.cc
@@ -158,7 +158,7 @@ class StatelessConnectionTerminator {
                 /*unused*/ QuicTime::Zero(), Perspective::IS_SERVER,
                 /*unused*/ kQuicDefaultConnectionIdLength),
         collector_(helper->GetStreamSendBufferAllocator()),
-        creator_(server_connection_id, &framer_, &collector_),
+        creator_(server_connection_id, &framer_, &collector_, nullptr),
         time_wait_list_manager_(time_wait_list_manager) {
     framer_.set_data_producer(&collector_);
     // Always set encrypter with original_server_connection_id.

--- a/quiche/quic/core/quic_packet_creator.cc
+++ b/quiche/quic/core/quic_packet_creator.cc
@@ -1694,6 +1694,7 @@ void QuicPacketCreator::FillPacketHeader(QuicPacketHeader* header) {
   header->destination_connection_id = GetDestinationConnectionId();
   header->destination_connection_id_included =
       GetDestinationConnectionIdIncluded();
+  QUIC_DVLOG(1) << ENDPOINT << "destination_connection_id: " << header->destination_connection_id;
   header->source_connection_id = GetSourceConnectionId();
   header->source_connection_id_included = GetSourceConnectionIdIncluded();
   header->reset_flag = false;
@@ -1748,6 +1749,8 @@ void QuicPacketCreator::ResetSpinBit() {
   current_spin_bit_ = false;
   spin_bit_interval_ = QuicTime::Zero();
   latest_rtt_ = QuicTime::Delta::Zero();
+  QUIC_DVLOG(0) << ENDPOINT
+                << "Resetting current_spin_bit_";
 }
 
 void QuicPacketCreator::MaybeUpdateLatestRtt(QuicTime::Delta latest_rtt) {
@@ -2082,6 +2085,7 @@ void QuicPacketCreator::SetServerConnectionIdIncluded(
 void QuicPacketCreator::SetServerConnectionId(
     QuicConnectionId server_connection_id) {
   server_connection_id_ = server_connection_id;
+  ResetSpinBit();
 }
 
 void QuicPacketCreator::SetClientConnectionId(

--- a/quiche/quic/core/quic_packet_creator.cc
+++ b/quiche/quic/core/quic_packet_creator.cc
@@ -1744,6 +1744,12 @@ void QuicPacketCreator::MaybeFlipSpinBit() {
     }
 }
 
+void QuicPacketCreator::ResetSpinBit() {
+  current_spin_bit_ = false;
+  spin_bit_interval_ = QuicTime::Zero();
+  latest_rtt_ = QuicTime::Delta::Zero();
+}
+
 void QuicPacketCreator::MaybeUpdateLatestRtt(QuicTime::Delta latest_rtt) {
   if (!latest_rtt.IsZero() && latest_rtt != latest_rtt_) {
       QUIC_DVLOG(1) << ENDPOINT

--- a/quiche/quic/core/quic_packet_creator.cc
+++ b/quiche/quic/core/quic_packet_creator.cc
@@ -23,6 +23,7 @@
 #include "quiche/quic/core/frames/quic_path_challenge_frame.h"
 #include "quiche/quic/core/frames/quic_stream_frame.h"
 #include "quiche/quic/core/quic_chaos_protector.h"
+#include "quiche/quic/core/quic_clock.h"
 #include "quiche/quic/core/quic_connection_id.h"
 #include "quiche/quic/core/quic_constants.h"
 #include "quiche/quic/core/quic_data_writer.h"
@@ -105,13 +106,15 @@ class ScopedPacketContextSwitcher {
 
 QuicPacketCreator::QuicPacketCreator(QuicConnectionId server_connection_id,
                                      QuicFramer* framer,
-                                     DelegateInterface* delegate)
+                                     DelegateInterface* delegate,
+                                     const QuicClock* clock)
     : QuicPacketCreator(server_connection_id, framer, QuicRandom::GetInstance(),
-                        delegate) {}
+                        delegate, clock) {}
 
 QuicPacketCreator::QuicPacketCreator(QuicConnectionId server_connection_id,
                                      QuicFramer* framer, QuicRandom* random,
-                                     DelegateInterface* delegate)
+                                     DelegateInterface* delegate,
+                                     const QuicClock* clock)
     : delegate_(delegate),
       debug_delegate_(nullptr),
       framer_(framer),
@@ -131,7 +134,8 @@ QuicPacketCreator::QuicPacketCreator(QuicConnectionId server_connection_id,
       flusher_attached_(false),
       fully_pad_crypto_handshake_packets_(true),
       latched_hard_max_packet_length_(0),
-      max_datagram_frame_size_(0) {
+      max_datagram_frame_size_(0),
+      clock_(clock) {
   SetMaxPacketLength(kDefaultMaxPacketSize);
   if (!framer_->version().UsesTls()) {
     // QUIC+TLS negotiates the maximum datagram frame size via the

--- a/quiche/quic/core/quic_packet_creator.cc
+++ b/quiche/quic/core/quic_packet_creator.cc
@@ -1715,7 +1715,7 @@ void QuicPacketCreator::FillPacketHeader(QuicPacketHeader* header) {
   if (!HasIetfLongHeader()) {
     MaybeFlipSpinBit();
     QUIC_DVLOG(1) << ENDPOINT << "Packet number: " << header->packet_number
-                  << ", Spin Bit: " << current_spin_bit_
+                  << ", Spin Bit: " << current_spin_bit_;
     header->spin_bit = current_spin_bit_;
     return;
   }

--- a/quiche/quic/core/quic_packet_creator.h
+++ b/quiche/quic/core/quic_packet_creator.h
@@ -36,6 +36,9 @@
 #include "quiche/common/quiche_circular_deque.h"
 
 namespace quic {
+
+class QuicClock;
+
 namespace test {
 class QuicPacketCreatorPeer;
 }
@@ -334,6 +337,9 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
 
   // Getter method for latest_rtt_received_.
   QuicTime::Delta GetLatestRttReceived() const { return latest_rtt_received_; }
+
+  // Flips the Spin Bit according to the Internal Spin Bit logic.
+  void MaybeFlipSpinBit();
 
   bool has_stop_waiting() const { return packet_.has_stop_waiting; }
 
@@ -716,6 +722,9 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
 
   // Latest RTT received from the connection.
   QuicTime::Delta latest_rtt_received_;
+
+  // Clock used to compute the Internal Spin Bit marking interval.
+  const QuicClock* clock_;
 
 };
 

--- a/quiche/quic/core/quic_packet_creator.h
+++ b/quiche/quic/core/quic_packet_creator.h
@@ -322,23 +322,26 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
 
   bool has_ack() const { return packet_.has_ack; }
 
-  // Setter method for current_spin_bit.
-  void SetCurrentSpinBit(bool spin_bit) {current_spin_bit = spin_bit;}
+  // Setter method for current_spin_bit_.
+  void SetCurrentSpinBit(bool spin_bit) { current_spin_bit_ = spin_bit; }
 
-  // Getter method for current_spin_bit.
-  bool GetCurrentSpinBit() const {return current_spin_bit;}
+  // Getter method for current_spin_bit_.
+  bool GetCurrentSpinBit() const { return current_spin_bit_; }
 
-  // Setter method for spin_bit_interval.
-  void SetSpinBitInterval(QuicTime interval) {spin_bit_interval = interval;}
+  // Setter method for spin_bit_interval_.
+  void SetSpinBitInterval(QuicTime interval) { spin_bit_interval_ = interval; }
 
-  // Getter method for spin_bit_interval.
-  QuicTime GetSpinBitInterval() const {return spin_bit_interval;}
+  // Getter method for spin_bit_interval_.
+  QuicTime GetSpinBitInterval() const { return spin_bit_interval_; }
 
-  // Setter method for latest_rtt_received_.
-  void SetLatestRttReceived(QuicTime::Delta latest_rtt) { latest_rtt_received_ = latest_rtt; }
+  // Setter method for latest_rtt_.
+  void SetLatestRtt(QuicTime::Delta latest_rtt) { latest_rtt_ = latest_rtt; }
 
-  // Getter method for latest_rtt_received_.
-  QuicTime::Delta GetLatestRttReceived() const { return latest_rtt_received_; }
+  // Getter method for latest_rtt_.
+  QuicTime::Delta GetLatestRtt() const { return latest_rtt_; }
+
+  // Update latest_rtt_ if needed.
+  void MaybeUpdateLatestRtt(QuicTime::Delta latest_rtt);
 
   // Flips the Spin Bit according to the Internal Spin Bit logic.
   void MaybeFlipSpinBit();
@@ -716,14 +719,14 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
   QuicByteCount max_datagram_frame_size_;
 
   // Spin Bit value manintained internally by the endpoint.
-  bool current_spin_bit = false;
+  bool current_spin_bit_ = false;
 
   // Interval used for Internal Spin Bit marking. It is the sum of the
   // current time and the latest RTT.
-  QuicTime spin_bit_interval = QuicTime::Zero();
+  QuicTime spin_bit_interval_ = QuicTime::Zero();
 
-  // Latest RTT received from the connection.
-  QuicTime::Delta latest_rtt_received_ = QuicTime::Delta::Zero();
+  // Latest RTT received from the Connection.
+  QuicTime::Delta latest_rtt_ = QuicTime::Delta::Zero();
 
   // Clock used to compute the Internal Spin Bit marking interval.
   const QuicClock* clock_;

--- a/quiche/quic/core/quic_packet_creator.h
+++ b/quiche/quic/core/quic_packet_creator.h
@@ -28,6 +28,7 @@
 #include "quiche/quic/core/quic_connection_id.h"
 #include "quiche/quic/core/quic_framer.h"
 #include "quiche/quic/core/quic_packets.h"
+#include "quiche/quic/core/quic_time.h"
 #include "quiche/quic/core/quic_types.h"
 #include "quiche/quic/platform/api/quic_export.h"
 #include "quiche/quic/platform/api/quic_flags.h"
@@ -328,6 +329,12 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
   // Getter method for spin_bit_interval.
   QuicTime GetSpinBitInterval() const {return spin_bit_interval;}
 
+  // Setter method for latest_rtt_received_.
+  void SetLatestRttReceived(QuicTime::Delta latest_rtt) { latest_rtt_received_ = latest_rtt; }
+
+  // Getter method for latest_rtt_received_.
+  QuicTime::Delta GetLatestRttReceived() const { return latest_rtt_received_; }
+
   bool has_stop_waiting() const { return packet_.has_stop_waiting; }
 
   // Sets the encrypter to use for the encryption level and updates the max
@@ -369,7 +376,8 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
   // accommodate, the padding will overflow to the next packet(s).
   QuicConsumedData ConsumeData(QuicStreamId id, size_t write_length,
                                QuicStreamOffset offset,
-                               StreamSendingState state);
+                               StreamSendingState state,
+                               QuicTime::Delta latest_rtt);
 
   // Sends as many data only packets as allowed by the send algorithm and the
   // available iov.
@@ -705,6 +713,9 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
   // Interval used for Internal Spin Bit marking. It is the sum of the
   // current time and the latest RTT.
   QuicTime spin_bit_interval = QuicTime::Zero();
+
+  // Latest RTT received from the connection.
+  QuicTime::Delta latest_rtt_received_;
 
 };
 

--- a/quiche/quic/core/quic_packet_creator.h
+++ b/quiche/quic/core/quic_packet_creator.h
@@ -24,6 +24,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "quiche/quic/core/frames/quic_stream_frame.h"
+#include "quiche/quic/core/quic_clock.h"
 #include "quiche/quic/core/quic_coalesced_packet.h"
 #include "quiche/quic/core/quic_connection_id.h"
 #include "quiche/quic/core/quic_framer.h"
@@ -115,9 +116,10 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
   };
 
   QuicPacketCreator(QuicConnectionId server_connection_id, QuicFramer* framer,
-                    DelegateInterface* delegate);
+                    DelegateInterface* delegate, const QuicClock* clock);
   QuicPacketCreator(QuicConnectionId server_connection_id, QuicFramer* framer,
-                    QuicRandom* random, DelegateInterface* delegate);
+                    QuicRandom* random, DelegateInterface* delegate,
+                    const QuicClock* clock);
   QuicPacketCreator(const QuicPacketCreator&) = delete;
   QuicPacketCreator& operator=(const QuicPacketCreator&) = delete;
 
@@ -721,7 +723,7 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
   QuicTime spin_bit_interval = QuicTime::Zero();
 
   // Latest RTT received from the connection.
-  QuicTime::Delta latest_rtt_received_;
+  QuicTime::Delta latest_rtt_received_ = QuicTime::Delta::Zero();
 
   // Clock used to compute the Internal Spin Bit marking interval.
   const QuicClock* clock_;

--- a/quiche/quic/core/quic_packet_creator.h
+++ b/quiche/quic/core/quic_packet_creator.h
@@ -346,6 +346,10 @@ class QUIC_EXPORT_PRIVATE QuicPacketCreator {
   // Flips the Spin Bit according to the Internal Spin Bit logic.
   void MaybeFlipSpinBit();
 
+  // After a migration the Connection ID is changed and the RTT stats are
+  // reset: according to the RFC 9000 we should reset the Spin Bit.
+  void ResetSpinBit();
+
   bool has_stop_waiting() const { return packet_.has_stop_waiting; }
 
   // Sets the encrypter to use for the encryption level and updates the max


### PR DESCRIPTION
Roadmap:

- [x] Move Spin Bit flips to QuicPacketCreator:
  - [x] timely pass the `latest_rtt` from QuicConnection, since QuicPacketCreator cannot access RttStats;
  - [x] when filling the header check if we need to update the interval, and if so flip the Spin Bit as well;
  - [x] since the above step requires a clock, make sure it works properly with `latest_rtt`;
  - [x] remove the old implementation.
- [x] Reset the Spin Bit when the ConnectionID changes:
  - [x] we should also reset the interval.